### PR TITLE
Substitutes ArrayBuffer in favor of VertexBuffer.

### DIFF
--- a/src/Renderable.js
+++ b/src/Renderable.js
@@ -1,5 +1,5 @@
 import Body from "./Body.js";
-import ArrayBuffer from "mango/buffers/ArrayBuffer";
+import VertexBuffer from "mango/buffers/VertexBuffer";
 
 export default class Renderable extends Body {
   /**
@@ -20,7 +20,7 @@ export default class Renderable extends Body {
     // TODO make it an array like in batchrenderer
     this._drawMode = props.drawMode ? gl[props.drawMode] : gl.TRIANGLES;
 
-    this._buffer = new ArrayBuffer(gl,
+    this._buffer = new VertexBuffer(gl,
       this._shader.prepare(props.geometry),
       this._shader._STRIDE
     );

--- a/src/buffers/VertexBuffer.js
+++ b/src/buffers/VertexBuffer.js
@@ -1,6 +1,6 @@
 import Buffer from "./Buffer.js";
 
-export default class ArrayBuffer extends Buffer {
+export default class VertexBuffer extends Buffer {
   constructor (gl, data, componentCount=3) {
     super(gl);
 
@@ -8,7 +8,7 @@ export default class ArrayBuffer extends Buffer {
     this._target = gl.ARRAY_BUFFER;
 
     if (!this._buffer)
-      throw new Error('ArrayBuffer: Error while creating buffer');
+      throw new Error('VertexBuffer: Error while creating buffer');
 
     gl.bindBuffer(this._target, this._buffer);
     gl.bufferData(this._target, data, gl.STATIC_DRAW);

--- a/src/geometries/Square.js
+++ b/src/geometries/Square.js
@@ -1,4 +1,4 @@
-import ArrayBuffer from "../buffers/ArrayBuffer.js";
+import VertexBuffer from "../buffers/VertexBuffer.js";
 import IndexBuffer from "../buffers/IndexBuffer.js";
 
 export default class Square {

--- a/src/shaders/basic/BasicShader.js
+++ b/src/shaders/basic/BasicShader.js
@@ -2,7 +2,7 @@ import {mat4} from "gl-matrix";
 import vshader from "./basic.vert";
 import fshader from "./basic.frag";
 import Shader from "../Shader.js";
-import ArrayBuffer from "../../buffers/ArrayBuffer.js";
+import VertexBuffer from "../../buffers/VertexBuffer.js";
 
 const FLOAT32_SIZE = new Float32Array().BYTES_PER_ELEMENT;
 const _STRIDE = 6;

--- a/src/shaders/normals/NormalsShader.js
+++ b/src/shaders/normals/NormalsShader.js
@@ -2,7 +2,7 @@ import vshader from "./normals.vert";
 import fshader from "./normals.frag";
 
 import Shader from "../Shader.js";
-import ArrayBuffer from "../../buffers/ArrayBuffer.js";
+import VertexBuffer from "../../buffers/VertexBuffer.js";
 
 const _STRIDE = 6;
 const _FLOAT32_SIZE = new Float32Array().BYTES_PER_ELEMENT;


### PR DESCRIPTION
There's already an ArrayBuffer object in plain JS so we'd override it
when declaring our own. This commit fixes it.
